### PR TITLE
Tweaked build setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "cjs": {
+      "presets": [["env", { "loose": true }]],
+    },
+    "es": {
+      "presets": [["env", { "loose": true, "modules": false }]],
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 
 # Transpiled lib
 lib
+es
 
 # Files marked with gitigx
 *gitigx*

--- a/package.json
+++ b/package.json
@@ -3,13 +3,18 @@
   "version": "1.0.4",
   "description": "Detect if the browser supports passive events",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "scripts": {
-    "build": "rm -rf lib && babel src --presets babel-preset-es2015 -d lib",
+    "clean": "rimraf es lib",
+    "prebuild": "npm run clean",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src -d lib",
+    "build:es": "cross-env BABEL_ENV=es babel src -d es",
     "prepublish": "npm run build"
   },
   "files": [
     "lib",
-    "src"
+    "es"
   ],
   "repository": {
     "type": "git",
@@ -29,9 +34,11 @@
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-eslint": "^7.1.1",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
+    "cross-env": "^5.1.0",
     "eslint": "^3.16.1",
     "eslint-config-airbnb-base": "^10.0.1",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint-plugin-import": "^2.2.0",
+    "rimraf": "^2.6.2"
   }
 }


### PR DESCRIPTION
- using cross-platform packages (`rimraf` and `cross-env`)
- updated deprecated `babel-preset-es2015` to the preferred one - `babel-preset-env`
- transpiling for 2 targets - commonjs and es modules, latter gives better tree-shakeability (nice to have if you decide to land [this PR](https://github.com/rafrex/detect-passive-events/pull/4)) and often it allows bundlers like webpack or rollup to optimize the output in various ways, like i.e. it doesnt have to be wrapped when webpack performs scope hoisting with `ModuleConcatenationPlugin` plugin