### PR TITLE
check that window.removeEventListener is a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // adapted from https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 const detectPassiveEvents = {
   update() {
-    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function' && typeof window.removeEventListener === 'function') {
       let passive = false;
       const options = Object.defineProperty({}, 'passive', {
         get() { passive = true; },


### PR DESCRIPTION
this was throwing an error for us, because window.removeEventListener was not defined for some reason.